### PR TITLE
content/news: Add quick links to the top

### DIFF
--- a/content/news.md
+++ b/content/news.md
@@ -1,21 +1,20 @@
 +++
 +++
 
-## Quick Links
-- **[Watch the stream at https://twitch.tv/coderefinery](https://twitch.tv/coderefinery) (shareable).**
-- Open the relevant lesson according to the schedule below (shareable)
-- Collaborative doc (our "chat") is to registered participants (please
-  don't share).
-- [Q&A of each day is archived on this site](questions/) (shareable)
+### Quick Links
+
+- **Watch the stream at [https://twitch.tv/coderefinery](https://twitch.tv/coderefinery)** (shareable)
+- Links to lesson material in the schedule below (shareable)
+- Collaborative document for questions and notes (please register to receive it)
+- Q&A of each day is archived on [this site](questions/) (shareable)
 - [Archive of past communication to participants](communication/) (shareable)
-- Videos on [Twitch for 7
-  days](https://www.twitch.tv/coderefinery/videos) days immediately
-  and [this YouTube
-  playlist before midnight Helsinki time](https://www.youtube.com/playlist?list=PLpLblYHCzJACsZllghoLA4JBMjkTk0eq4).
+- Videos [on Twitch](https://www.twitch.tv/coderefinery/videos) for 7 days immediately
+  and [on YouTube](https://www.youtube.com/playlist?list=PLpLblYHCzJACsZllghoLA4JBMjkTk0eq4) later same day
 
 
 ### News
 
+- Automatic confirmation emails sometimes go to spam. We will email a summary to all registrants before the workshop.
 - March 14: We now also provide a [verification script](https://coderefinery.github.io/installation/#step-1-go-through-the-checklist-and-make-sure-all-items-are-ready)
   to help you check software and configuration
 - March 14: 400 registrations.

--- a/content/news.md
+++ b/content/news.md
@@ -1,7 +1,20 @@
 +++
 +++
 
-## News
+## Quick Links
+- **[Watch the stream at https://twitch.tv/coderefinery](https://twitch.tv/coderefinery) (shareable).**
+- Open the relevant lesson according to the schedule below (shareable)
+- Collaborative doc (our "chat") is to registered participants (please
+  don't share).
+- [Q&A of each day is archived on this site](questions/) (shareable)
+- [Archive of past communication to participants](communication/) (shareable)
+- Videos on [Twitch for 7
+  days](https://www.twitch.tv/coderefinery/videos) days immediately
+  and [this YouTube
+  playlist before midnight Helsinki time](https://www.youtube.com/playlist?list=PLpLblYHCzJACsZllghoLA4JBMjkTk0eq4).
+
+
+### News
 
 - March 14: We now also provide a [verification script](https://coderefinery.github.io/installation/#step-1-go-through-the-checklist-and-make-sure-all-items-are-ready)
   to help you check software and configuration
@@ -9,5 +22,5 @@
 - March 9: Pre-workshop emails sent (you can find them [here](communication/)) and no problem to register after today
 - We will not offer CodeRefinery exercise Zoom this time but we will rather focus on supporting self-organized teams and on
   offering a good workshop experience also for individual learners.
-- March 7: [Install instructions](https://coderefinery.github.io/installation/) are ready
+- March 7: [Install instructions](https://coderefinery.github.io/installation/) are ready (git/github/ssh is most important for week 1)
 - March 3: We have reached 200 registrations! 


### PR DESCRIPTION
- This gets relatively long but is similar to how previous years started.  By the end "obvious" links like the stream were removed in favor of other news articles.